### PR TITLE
Add validation check for empty L2Services list

### DIFF
--- a/api/v1alpha1/l2serviceattachment_types.go
+++ b/api/v1alpha1/l2serviceattachment_types.go
@@ -28,6 +28,7 @@ type L2ServiceAttachmentSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
+	// +kubebuilder:validation:MinItems:=1
 	L2Services      []string `json:"L2Services"`
 	ConnectionPoint string   `json:"ConnectionPoint"`
 	// +kubebuilder:validation:Enum=kernel;dpdk

--- a/config/crd/bases/eno.k8s.io_l2serviceattachments.yaml
+++ b/config/crd/bases/eno.k8s.io_l2serviceattachments.yaml
@@ -47,6 +47,7 @@ spec:
             L2Services:
               items:
                 type: string
+              minItems: 1
               type: array
             PodInterfaceType:
               enum:


### PR DESCRIPTION
Valid L2serviceattachments should have at least one
L2service in L2services list field.

More info: https://github.com/Nordix/eno/issues/3

Signed-off-by: Dimitrios Markou <dimitrios.markou@est.tech>