### PR TITLE
Upgrade go in Dockerfile to 1.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.13 as builder
+FROM golang:1.15 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
In the go.mod file is stated that we support go 1.15 version.
The same allignment needs to be made in the Dockerfile.

Signed-off-by: Dimitrios Markou <dimitrios.markou@est.tech>